### PR TITLE
Add Supabase authentication and saved report workflow

### DIFF
--- a/api/save-report.js
+++ b/api/save-report.js
@@ -21,6 +21,10 @@ export default async function handler(req, res) {
   try {
     const payload = req.body || {};
 
+    if (!payload.userId) {
+      return res.status(400).json({ success: false, error: 'User ID is required to save a report.' });
+    }
+
     // Build embedding text
     const textToEmbed = `${payload.propertyInfo?.name || ''}, ${payload.propertyInfo?.state || ''}\n${payload.htmlContent || ''}`;
 
@@ -35,6 +39,9 @@ export default async function handler(req, res) {
 
     // Map payload → Supabase schema
     const fieldMap = {
+      user_id: payload.userId,
+      report_name: payload.reportName,
+      report_state: payload.reportState,
       user_name: payload.contactInfo?.name,
       user_email: payload.contactInfo?.email,
       user_phone: payload.contactInfo?.phone,
@@ -53,15 +60,15 @@ export default async function handler(req, res) {
       loan_term_years: payload.purchaseInputs?.loanTermYears,
       monthly_payment: payload.purchaseInputs?.monthlyPayment,
       annual_debt_service: payload.purchaseInputs?.annualDebtService,
-      total_lots: payload.propertyInfo?.totalLots,
-      occupied_lots: payload.propertyInfo?.occupiedLots,
-      physical_occupancy: payload.propertyInfo?.physicalOccupancy,
-      economic_occupancy: payload.propertyInfo?.economicOccupancy,
+      total_lots: payload.propertyInfo?.totalLots ?? payload.calculations?.totalUnits,
+      occupied_lots: payload.propertyInfo?.occupiedLots ?? payload.calculations?.occupiedUnits,
+      physical_occupancy: payload.propertyInfo?.physicalOccupancy ?? payload.calculations?.physicalOccupancy,
+      economic_occupancy: payload.propertyInfo?.economicOccupancy ?? payload.calculations?.economicOccupancy,
       gross_potential_rent: payload.calculations?.grossPotentialRent,
       lot_rent_income: payload.calculations?.lotRentIncome,
-      other_income: payload.calculations?.otherIncome,
+      other_income: payload.calculations?.totalAdditionalIncome,
       effective_gross_income: payload.calculations?.effectiveGrossIncome,
-      total_operating_expenses: payload.calculations?.totalOperatingExpenses,
+      total_operating_expenses: payload.calculations?.totalOpEx,
       management_fee: payload.calculations?.managementFee,
       noi: payload.calculations?.noi,
       cap_rate: payload.calculations?.capRate,
@@ -69,15 +76,20 @@ export default async function handler(req, res) {
       dscr: payload.calculations?.dscr,
       irr: payload.calculations?.irr,
       equity_multiple: payload.calculations?.equityMultiple,
-      annual_cash_flow: payload.calculations?.annualCashFlow,
+      annual_cash_flow: payload.calculations?.cashFlow,
       income_per_unit: payload.calculations?.incomePerUnit,
       expense_per_unit: payload.calculations?.expensePerUnit,
       noi_per_unit: payload.calculations?.noiPerUnit,
       report_html: payload.htmlContent || '',
-      rent_roll: payload.rentRoll || {},
-      income_items: payload.incomeItems || {},
-      expense_items: payload.expenses || {},
-      additional_income: payload.additionalIncome || {},
+      rent_roll: payload.units || [],
+      income_items: payload.additionalIncome || [],
+      expense_items: payload.expenses || [],
+      additional_income: payload.additionalIncome || [],
+      management_percent: payload.managementPercent,
+      irr_inputs: payload.irrInputs,
+      proforma_inputs: payload.proformaInputs,
+      use_actual_income: payload.useActualIncome,
+      actual_income: payload.actualIncome,
       embedding,
     };
 
@@ -86,20 +98,36 @@ export default async function handler(req, res) {
       Object.entries(fieldMap).filter(([_, v]) => v !== undefined && v !== null && v !== '')
     );
 
-    const { data, error } = await supabase.from('reports').insert([insertData]).select();
+    let query = supabase.from('reports');
+
+    let data;
+    let error;
+
+    if (payload.reportId) {
+      ({ data, error } = await query
+        .update(insertData)
+        .eq('id', payload.reportId)
+        .eq('user_id', payload.userId)
+        .select());
+    } else {
+      ({ data, error } = await query.insert([insertData]).select());
+    }
 
     if (error) {
       console.error('Supabase insert error:', error);
       return res.status(500).json({ error: error.message });
     }
 
-    // ✅ Send full HTML report in the email body
-    await resend.emails.send({
-      from: 'onboarding@resend.dev',
-      to: 'boschtj@gmail.com',
-      subject: `New Report Saved: ${payload.propertyInfo?.name || 'Unknown Property'}`,
-      html: payload.htmlContent || `<p>New report saved for ${payload.propertyInfo?.name || 'Unknown Property'}</p>`,
-    });
+    if (!payload.reportId) {
+      await resend.emails.send({
+        from: 'onboarding@resend.dev',
+        to: 'boschtj@gmail.com',
+        subject: `New Report Saved: ${payload.reportName || payload.propertyInfo?.name || 'Unknown Property'}`,
+        html:
+          payload.htmlContent ||
+          `<p>New report saved for ${payload.reportName || payload.propertyInfo?.name || 'Unknown Property'}</p>`,
+      });
+    }
 
     return res.status(200).json({ success: true, data });
   } catch (err) {

--- a/src/components/AuthModal.js
+++ b/src/components/AuthModal.js
@@ -1,0 +1,161 @@
+import React, { useState } from 'react';
+import supabase, { isSupabaseConfigured } from '../supabaseClient';
+
+const AuthModal = ({ isOpen, onClose, onAuthSuccess }) => {
+  const [mode, setMode] = useState('sign-in');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const resetForm = () => {
+    setEmail('');
+    setPassword('');
+    setError('');
+    setMode('sign-in');
+  };
+
+  const closeModal = () => {
+    resetForm();
+    onClose?.();
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!isSupabaseConfigured || !supabase) {
+      setError('Supabase is not configured. Please add your environment variables to enable authentication.');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    const credentials = { email, password };
+    try {
+      let response;
+      if (mode === 'sign-in') {
+        response = await supabase.auth.signInWithPassword(credentials);
+      } else {
+        response = await supabase.auth.signUp(credentials);
+      }
+
+      if (response?.error) {
+        setError(response.error.message);
+        return;
+      }
+
+      if (mode === 'sign-up') {
+        setError('Check your email to confirm your account before signing in.');
+      } else {
+        onAuthSuccess?.();
+        closeModal();
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-md p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-gray-800">
+            {mode === 'sign-in' ? 'Sign in to your account' : 'Create a new account'}
+          </h2>
+          <button
+            type="button"
+            className="text-gray-500 hover:text-gray-700"
+            onClick={closeModal}
+          >
+            ×
+          </button>
+        </div>
+
+        {!isSupabaseConfigured && (
+          <div className="mb-4 rounded border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+            Supabase credentials are not configured. Add REACT_APP_SUPABASE_URL and
+            REACT_APP_SUPABASE_ANON_KEY to enable authentication.
+          </div>
+        )}
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Email</label>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+              placeholder="you@example.com"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Password</label>
+            <input
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+              placeholder="Enter a secure password"
+            />
+          </div>
+
+          {error && (
+            <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-600">{error}</div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded bg-blue-600 px-4 py-2 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+          >
+            {loading ? 'Processing...' : mode === 'sign-in' ? 'Sign In' : 'Sign Up'}
+          </button>
+        </form>
+
+        <div className="mt-4 text-center text-sm text-gray-600">
+          {mode === 'sign-in' ? (
+            <span>
+              Need an account?{' '}
+              <button
+                type="button"
+                className="font-semibold text-blue-600 hover:text-blue-700"
+                onClick={() => {
+                  setMode('sign-up');
+                  setError('');
+                }}
+              >
+                Create one
+              </button>
+            </span>
+          ) : (
+            <span>
+              Already registered?{' '}
+              <button
+                type="button"
+                className="font-semibold text-blue-600 hover:text-blue-700"
+                onClick={() => {
+                  setMode('sign-in');
+                  setError('');
+                }}
+              >
+                Sign in
+              </button>
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AuthModal;

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,0 +1,18 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
+const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  if (typeof console !== 'undefined') {
+    console.warn('Supabase environment variables are not configured. Authentication features are disabled.');
+  }
+}
+
+const supabase = supabaseUrl && supabaseAnonKey
+  ? createClient(supabaseUrl, supabaseAnonKey)
+  : null;
+
+export const isSupabaseConfigured = Boolean(supabase);
+
+export default supabase;


### PR DESCRIPTION
## Summary
- add Supabase client utilities and an authentication modal for end-user sign in
- integrate session-aware report saving/loading controls and hook downloads to account storage
- update the save-report API to persist user-linked report metadata and support updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e58e5d068083289562895a3b7c0b7f